### PR TITLE
Improve cross-platform shortcuts and shell helpers

### DIFF
--- a/common/shortcuts.yml
+++ b/common/shortcuts.yml
@@ -10,19 +10,22 @@
   cat: CONFIG
   desc: shortcuts.yml edit
   cmd:
-    win:  'Edit-File "E:\Configs\dotfiles\common\shortcuts.yml"'
+    win:   'Edit-File "E:\Configs\dotfiles\common\shortcuts.yml"'
+    linux: '${EDITOR:-vim} "$DOTFILES/common/shortcuts.yml"'
 
 - name: pro
   cat: CONFIG
   desc: PS profile (tmpl) edit
   cmd:
-    win:  '$p=(chezmoi source-path $PROFILE); Edit-File $p'
+    win:   '$p=(chezmoi source-path $PROFILE); Edit-File $p'
+    linux: '${EDITOR:-vim} "$DOTFILES/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl"'
 
 - name: fresh
   cat: CONFIG
   desc: Profile reload
   cmd:
-    win:  '. $PROFILE'
+    win:   '. $PROFILE'
+    linux: 'source ~/.bashrc'
 
 - name: chez
   cat: CONFIG
@@ -40,7 +43,8 @@
   cat: CONFIG
   desc: .gitconfig edit
   cmd:
-    win:  'Edit-File "$HOME\.gitconfig"'
+    win:   'Edit-File "$HOME\.gitconfig"'
+    linux: '${EDITOR:-vim} "$HOME/.gitconfig"'
 
 # ==== DIRECTORIES ====
 
@@ -48,7 +52,8 @@
   cat: DIRS
   desc: SSH Keys
   cmd:
-    win:  'cd "$HOME\.ssh"; ls'
+    win:   'cd "$HOME\.ssh"; ls'
+    linux: 'cd "$HOME/.ssh"; ls'
 
 - name: down
   cat: DIRS

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -120,13 +120,49 @@ fi
 # Default editor
 export EDITOR=vim
 
-# Git helper (allg = all git)
+# Resolve the dotfiles source directory for reuse in shortcuts
+if [ -z "${DOTFILES:-}" ]; then
+  if command -v chezmoi >/dev/null 2>&1; then
+    DOTFILES="$(chezmoi source-path 2>/dev/null || true)"
+  fi
+  DOTFILES="${DOTFILES:-$HOME/.dotfiles}"
+fi
+export DOTFILES
+
+# Load generated helper functions (shortcuts, etc.)
+if [ -f "$HOME/.bash_functions" ]; then
+  # shellcheck disable=SC1090
+  . "$HOME/.bash_functions"
+fi
+
+# Git helper for add/status/commit/push
 allg() {
-  git add .
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Not inside a Git repository."
+    return 1
+  fi
+
+  git add -A
   git status
-  echo "Enter commit message: "
-  read commitMessage
-  git commit -m "$commitMessage"
-  git push -u origin main
+
+  local message="$1"
+  if [ -z "$message" ]; then
+    read -r -p "Enter commit message: " message
+  fi
+
+  if [ -z "$message" ]; then
+    echo "Aborted: empty commit message."
+    return 1
+  fi
+
+  git commit -m "$message" || return 1
+
+  local branch
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  if git rev-parse --symbolic-full-name --abbrev-ref '@{u}' >/dev/null 2>&1; then
+    git push
+  else
+    git push -u origin "$branch"
+  fi
 }
 

--- a/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
+++ b/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
@@ -19,7 +19,7 @@ function Edit-File {
   & $editor $Path
 }
 
-# --- Shortcuts aus YAML laden ---
+# --- Load shortcuts from YAML ---
 $Shortcuts = @(
 {{ $data := (include "common/shortcuts.yml" | fromYaml) }}
 {{ range $data }}
@@ -35,13 +35,13 @@ $Shortcuts = @(
 {{ end }}
 )
 
-# --- Functions registrieren ---
+# --- Register shortcut functions ---
 foreach ($s in $Shortcuts) {
     if ([string]::IsNullOrWhiteSpace($s.cmd)) { continue }
     Set-Item -Path "function:$($s.name)" -Value ([scriptblock]::Create($s.cmd)) -Force
 }
 
-# --- Übersicht: shortcuts [KAT] ---
+# --- Overview: shortcuts [CATEGORY] ---
 function shortcuts {
     param([string]$Category)
     $Shortcuts
@@ -89,4 +89,4 @@ function allg {
 }
 
 try { Start-Service ssh-agent -ErrorAction SilentlyContinue | Out-Null } catch {}
-Write-Host "Profile geladen. 'shortcuts' listet alles, 'shortcuts DIRS' filtert."
+Write-Host "Profile loaded. 'shortcuts' lists everything, 'shortcuts DIRS' filters."


### PR DESCRIPTION
## Summary
- add Linux-aware commands to shared shortcuts so both shells expose the same helpers
- enhance the Bash profile to detect the dotfiles source, source generated helpers, and improve the git helper
- translate PowerShell profile comments to English for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca5052183c8333b4d789f82376ee5d