### PR TITLE
Auto-update dotfiles and show version on profile load

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ applied on both operating systems.
 
 | Path | Purpose |
 | --- | --- |
-| `dot_bashrc` | Bash profile applied in WSL. Detects the dotfiles directory, renders helper functions, and sources shared shortcuts. |
+| `dot_bashrc` | Bash profile applied in WSL. Detects the dotfiles directory, refreshes the checkout with `chezmoi update`, renders helper functions, and sources shared shortcuts. |
 | `home/dot_bash_functions.tmpl` | chezmoi template that turns the shared shortcut definitions into Bash functions. |
 | `readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl` | PowerShell profile template. chezmoi renders the final `Microsoft.PowerShell_profile.ps1` on Windows. |
 | `common/shortcuts.yml` | Single source of truth for helper commands and directory shortcuts that are rendered for both shells. |
@@ -23,6 +23,8 @@ applied on both operating systems.
    PowerShell profile, Bash helper functions, and any other managed files.
 4. Open a new terminal session. Bash regenerates `~/.bash_functions` on demand
    and automatically sources it, so the shortcut helpers are always available.
+   Both shells display the current Git branch and commit so you can see which
+   version of the dotfiles is active.
 
 ## Adding new shortcuts or aliases
 

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -120,6 +120,33 @@ fi
 # Default editor
 export EDITOR=vim
 
+# Automatically refresh dotfiles from chezmoi on shell start
+dotfiles_auto_update() {
+  if [ -n "${DOTFILES_PROFILE_AUTOUPDATED:-}" ]; then
+    return 0
+  fi
+
+  if ! command -v chezmoi >/dev/null 2>&1; then
+    return 0
+  fi
+
+  export DOTFILES_PROFILE_AUTOUPDATED=1
+
+  if chezmoi update >/dev/null 2>&1; then
+    if [ -f "$HOME/.bashrc" ]; then
+      # shellcheck disable=SC1090
+      . "$HOME/.bashrc"
+      return 0
+    fi
+  else
+    echo "Warning: chezmoi update failed." >&2
+  fi
+
+  return 0
+}
+
+dotfiles_auto_update
+
 # Resolve the dotfiles source directory for reuse in shortcuts
 if [ -z "${DOTFILES:-}" ]; then
   if command -v chezmoi >/dev/null 2>&1; then
@@ -196,7 +223,31 @@ generate_shortcut_helpers
 if [ -f "$HOME/.bash_functions" ]; then
   # shellcheck disable=SC1090
   . "$HOME/.bash_functions"
+else
+  echo "Warning: ~/.bash_functions is missing. Run 'chezmoi apply'." >&2
 fi
+
+dotfiles_print_version() {
+  local version="unknown"
+  local branch=""
+
+  if [ -n "$DOTFILES" ] && [ -d "$DOTFILES/.git" ] && command -v git >/dev/null 2>&1; then
+    version="$(git -C "$DOTFILES" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    branch="$(git -C "$DOTFILES" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
+      version="$branch@$version"
+    fi
+  fi
+
+  local platform="Linux"
+  if [ -n "${WSL_DISTRO_NAME:-}" ]; then
+    platform="WSL"
+  fi
+
+  printf 'Dotfiles version (%s): %s\n' "$platform" "$version"
+}
+
+dotfiles_print_version
 
 # Git helper for add/status/commit/push
 allg() {

--- a/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
+++ b/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
@@ -4,6 +4,24 @@ $ErrorActionPreference = "Stop"
 Set-Location $HOME
 if (-not $env:DOTFILES) { $env:DOTFILES = "E:\Configs\dotfiles" }
 
+if (-not $env:DOTFILES_PROFILE_AUTOUPDATED) {
+  $env:DOTFILES_PROFILE_AUTOUPDATED = '1'
+  if (Get-Command chezmoi -ErrorAction SilentlyContinue) {
+    try {
+      $updateOutput = chezmoi update 2>&1
+      if ($LASTEXITCODE -eq 0) {
+        if ($updateOutput) { Write-Verbose $updateOutput }
+        . $PROFILE
+        return
+      } else {
+        Write-Warning "chezmoi update failed:`n$updateOutput"
+      }
+    } catch {
+      Write-Warning "chezmoi update failed: $_"
+    }
+  }
+}
+
 # chezmoi environment-variable
 try { $env:CHEZMOI_SOURCE_DIR = (chezmoi source-path) } catch {}
 
@@ -89,4 +107,26 @@ function allg {
 }
 
 try { Start-Service ssh-agent -ErrorAction SilentlyContinue | Out-Null } catch {}
+
+function Show-DotfilesVersion {
+  $version = 'unknown'
+  $branch = $null
+
+  if ($env:DOTFILES -and (Test-Path (Join-Path $env:DOTFILES '.git'))) {
+    if (Get-Command git -ErrorAction SilentlyContinue) {
+      try {
+        $version = git -C $env:DOTFILES rev-parse --short HEAD 2>$null
+        $branch  = git -C $env:DOTFILES rev-parse --abbrev-ref HEAD 2>$null
+      } catch {}
+    }
+  }
+
+  if ($branch -and $branch -ne 'HEAD') {
+    $version = "$branch@$version"
+  }
+
+  Write-Host "Dotfiles version (Windows): $version"
+}
+
+Show-DotfilesVersion
 Write-Host "Profile loaded. 'shortcuts' lists everything, 'shortcuts DIRS' filters."


### PR DESCRIPTION
## Summary
- run `chezmoi update` once per session from the Bash and PowerShell profiles and reload them after a successful refresh
- warn when the generated Bash helper file is missing and display the active dotfiles Git branch and commit in both shells
- document the automatic refresh and version display in the README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ca8de29ff48333a0a1c02b7700af74