### PR TITLE
Fix chezmoi update verbose output formatting

### DIFF
--- a/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
+++ b/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
@@ -10,7 +10,7 @@ if (-not $env:DOTFILES_PROFILE_AUTOUPDATED) {
     try {
       $updateOutput = chezmoi update 2>&1
       if ($LASTEXITCODE -eq 0) {
-        if ($updateOutput) { Write-Verbose $updateOutput }
+        if ($updateOutput) { Write-Verbose (@($updateOutput) -join [Environment]::NewLine) }
         . $PROFILE
         return
       } else {


### PR DESCRIPTION
## Summary
- ensure verbose logging from the automatic chezmoi update joins multiple lines before emitting

## Testing
- not run (pwsh is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cb17b71c788333a927f3935cf3c622