### PR TITLE
Add functions listings for PowerShell and Bash

### DIFF
--- a/home/dot_bash_functions.tmpl
+++ b/home/dot_bash_functions.tmpl
@@ -34,6 +34,18 @@ shortcuts() {
   {{- end }}
 }
 
+functions() {
+  local filter="$1"
+  printf "%-12s %-10s %-s\n" "name" "cat" "desc"
+  {{- range $functions }}
+  {{- if and .linux (not (hasKey $shortcutFunctionRefs .name)) }}
+  if [ -z "$filter" ] || [ "$filter" = "{{ .cat }}" ]; then
+    printf "%-12s %-10s %-s\n" "{{ .name }}" "{{ .cat }}" "{{ .desc }}"
+  fi
+  {{- end }}
+  {{- end }}
+}
+
 # Render one function per shortcut/function (Linux command preferred, else 'both')
 {{- range $shortcuts }}
 {{- $cmd := .cmd -}}

--- a/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
+++ b/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
@@ -61,6 +61,18 @@ $Shortcuts = @(
 {{ end }}
 )
 
+$Functions = @(
+{{ range $functions }}
+  {{- if and .win (not (hasKey $shortcutFunctionRefs .name)) }}
+    [pscustomobject]@{
+        name = "{{ .name }}"
+        cat  = "{{ .cat }}"
+        desc = "{{ .desc }}"
+    };
+  {{- end }}
+{{ end }}
+)
+
 # --- Attach function helpers from YAML ---
 {{ range $functions }}
 {{- if .win }}
@@ -95,6 +107,15 @@ function shortcuts {
       | Format-Table -AutoSize
 }
 
+function functions {
+    param([string]$Category)
+    $Functions
+      | Where-Object { !$Category -or $_.cat -eq $Category }
+      | Sort-Object cat,name
+      | Select-Object name,cat,desc
+      | Format-Table -AutoSize
+}
+
 try { Start-Service ssh-agent -ErrorAction SilentlyContinue | Out-Null } catch {}
 
 function Show-DotfilesVersion {
@@ -118,4 +139,4 @@ function Show-DotfilesVersion {
 }
 
 Show-DotfilesVersion
-Write-Host "Profile loaded. 'shortcuts' lists everything, 'shortcuts DIRS' filters."
+Write-Host "Profile loaded. 'shortcuts' lists everything, 'functions' shows helpers."


### PR DESCRIPTION
## Summary
- build a `$Functions` metadata table in the PowerShell profile template and expose a category-aware `functions` helper
- add a parallel `functions()` helper to the Bash template that lists non-shortcut functions with category filtering

## Testing
- bash -lc '. /tmp/dot_bash_functions; functions'
- /tmp/powershell/pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File /tmp/test_functions.ps1


------
https://chatgpt.com/codex/tasks/task_e_68cb1c3f603c8333848ee4316c22d331