### PR TITLE
Prevent dot push/pull from falling through

### DIFF
--- a/common/functions.yml
+++ b/common/functions.yml
@@ -182,6 +182,8 @@
                 else {
                     allg
                 }
+
+                return # prevent falling through to default listing behaviour
             }
             '-pull' {
                 $remote = $null
@@ -198,6 +200,8 @@
                 else {
                     gall
                 }
+
+                return # prevent falling through to default listing behaviour
             }
             Default {
                 $listArgs = @()


### PR DESCRIPTION
## Summary
- add explicit returns to the Windows `dot` helper to avoid falling through to the default branch
- document the early returns to clarify the intent

## Testing
- `chezmoi apply` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb22a1e320833387cd8d53c721b554