### PR TITLE
Update dot helper to cd into DOTFILES

### DIFF
--- a/common/functions.yml
+++ b/common/functions.yml
@@ -140,23 +140,21 @@
       return 1
     fi
 
-    (
-      cd "$DOTFILES" || return 1
+    cd "$DOTFILES" || return 1
 
-      case "$1" in
-        -push)
-          shift
-          allg "$@"
-          ;;
-        -pull)
-          shift
-          gall "$@"
-          ;;
-        *)
-          ls -la "$@"
-          ;;
-      esac
-    )
+    case "$1" in
+      -push)
+        shift
+        allg "$@"
+        ;;
+      -pull)
+        shift
+        gall "$@"
+        ;;
+      *)
+        ls -la "$@"
+        ;;
+    esac
   win: |-
     param(
         [string]$Mode,


### PR DESCRIPTION
## Summary
- update the Linux dot helper to change into $DOTFILES in the current shell while keeping the push/pull helpers and default listing

## Testing
- chezmoi --source /workspace/win-wsl_dotfiles execute-template <home/dot_bash_functions.tmpl > /tmp/bash_functions
- bash -lc 'DOTFILES=/workspace/win-wsl_dotfiles; source /tmp/bash_functions; cd /; dot >/tmp/dot_ls; echo "after: $(pwd)"'

------
https://chatgpt.com/codex/tasks/task_e_68cbb7f18da4833390095852759ac9dd