### PR TITLE
Improve shortcut helper regeneration

### DIFF
--- a/dot_bashrc
+++ b/dot_bashrc
@@ -207,13 +207,28 @@ generate_shortcut_helpers() {
     return 0
   fi
 
-  if [ ! -f "$output" ] || [ "$template" -nt "$output" ] || [ "$DOTFILES/common/shortcuts.yml" -nt "$output" ] || [ "$DOTFILES/common/functions.yml" -nt "$output" ]; then
-    if chezmoi execute-template <"$template" >"$output"; then
-      chmod 600 "$output"
+  local tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/.bash_functions.XXXXXX")" || {
+    echo "Failed to create temporary file for Bash shortcuts." >&2
+    return 1
+  }
+
+  if ! chezmoi execute-template <"$template" >"$tmp"; then
+    echo "Failed to render Bash shortcuts from template." >&2
+    rm -f "$tmp"
+    return 1
+  fi
+
+  if [ ! -f "$output" ] || ! cmp -s "$tmp" "$output"; then
+    if chmod 600 "$tmp" && mv "$tmp" "$output"; then
+      :
     else
-      echo "Failed to render Bash shortcuts from template." >&2
+      echo "Failed to install rendered Bash shortcuts." >&2
+      rm -f "$tmp"
       return 1
     fi
+  else
+    rm -f "$tmp"
   fi
 }
 


### PR DESCRIPTION
## Summary
- render `.bash_functions` to a temporary file and replace the existing helper file only when the content changes
- keep early exit guards while ensuring helper regeneration no longer relies on file mtimes

## Testing
- DOTFILES=/workspace/win-wsl_dotfiles DOTFILES_PROFILE_AUTOUPDATED=1 WSL_DISTRO_NAME=Ubuntu HOME=/tmp/testhome bash --rcfile /workspace/win-wsl_dotfiles/dot_bashrc -i -c 'exit'
- grep -n "fast-forward" /tmp/testhome/.bash_functions

------
https://chatgpt.com/codex/tasks/task_e_68cbc8ff3a548333b83df3d6d1e3ed30