### PR TITLE
Add shared theme definitions

### DIFF
--- a/themes/monokai.yml
+++ b/themes/monokai.yml
@@ -1,0 +1,104 @@
+name: Monokai
+mode: dark
+font:
+  family: Cascadia Code PL
+  size: 11
+palette:
+  background: '#272822'
+  foreground: '#F8F8F2'
+  selection: '#49483E'
+  cursor: '#F8F8F0'
+  black: '#272822'
+  red: '#F92672'
+  green: '#A6E22E'
+  yellow: '#E6DB74'
+  blue: '#66D9EF'
+  purple: '#AE81FF'
+  cyan: '#A1EFE4'
+  white: '#F8F8F2'
+  brightBlack: '#75715E'
+  brightRed: '#F92672'
+  brightGreen: '#A6E22E'
+  brightYellow: '#F4BF75'
+  brightBlue: '#66D9EF'
+  brightPurple: '#AE81FF'
+  brightCyan: '#A1EFE4'
+  brightWhite: '#F9F8F5'
+accent:
+  color: '#AE81FF'
+wallpaper:
+  path: '%USERPROFILE%\\Pictures\\Wallpapers\\monokai.jpg'
+editors:
+  vscode:
+    theme: 'Monokai Dimmed'
+    cursorColor: '#F8F8F2'
+    selectionBackground: '#49483E'
+  neovim:
+    colorscheme: monokai
+  notepadpp:
+    theme: 'Monokai'
+  helix:
+    theme: monokai
+  sublimeText:
+    theme: 'Monokai.sublime-theme'
+targets:
+  windowsTerminal:
+    scheme:
+      name: Monokai
+      foreground: '#F8F8F2'
+      background: '#272822'
+      selectionBackground: '#49483E'
+      cursorColor: '#F8F8F0'
+      black: '#272822'
+      blue: '#66D9EF'
+      cyan: '#A1EFE4'
+      green: '#A6E22E'
+      purple: '#AE81FF'
+      red: '#F92672'
+      white: '#F8F8F2'
+      yellow: '#E6DB74'
+      brightBlack: '#75715E'
+      brightBlue: '#66D9EF'
+      brightCyan: '#A1EFE4'
+      brightGreen: '#A6E22E'
+      brightPurple: '#AE81FF'
+      brightRed: '#F92672'
+      brightWhite: '#F9F8F5'
+      brightYellow: '#F4BF75'
+    profileDefaults:
+      colorScheme: Monokai
+  powershell:
+    block: |-
+      # Monokai prompt colors
+      $env:PromptForeground = '#F8F8F2'
+      $env:PromptBackground = '#272822'
+  bash:
+    block: |-
+      # Monokai prompt colors
+      export PS1_COLOR_FG="#F8F8F2"
+      export PS1_COLOR_BG="#272822"
+  windows:
+    accentColor: '#AE81FF'
+    wallpaper: '%USERPROFILE%\\Pictures\\Wallpapers\\monokai.jpg'
+  vscode:
+    theme: 'Monokai Dimmed'
+    colorCustomizations:
+      editor.background: '#272822'
+      editor.foreground: '#F8F8F2'
+      editor.selectionBackground: '#49483E'
+      terminal.background: '#272822'
+      terminal.foreground: '#F8F8F2'
+  notepadpp:
+    content: |-
+      <?xml version="1.0" encoding="Windows-1252" ?>
+      <NotepadPlus>
+        <GlobalStyles>
+          <WidgetStyle name="Default Style" fgColor="F8F8F2" bgColor="272822" />
+          <WidgetStyle name="Selected text colour" fgColor="F8F8F2" bgColor="49483E" />
+        </GlobalStyles>
+      </NotepadPlus>
+  vim:
+    block: |-
+      " Monokai theme integration
+      set background=dark
+      colorscheme monokai

--- a/themes/solarized-dark.yml
+++ b/themes/solarized-dark.yml
@@ -1,0 +1,105 @@
+name: Solarized Dark
+mode: dark
+font:
+  family: Fira Code
+  size: 11
+palette:
+  background: '#002b36'
+  foreground: '#839496'
+  selection: '#073642'
+  cursor: '#93a1a1'
+  black: '#073642'
+  red: '#dc322f'
+  green: '#859900'
+  yellow: '#b58900'
+  blue: '#268bd2'
+  purple: '#6c71c4'
+  cyan: '#2aa198'
+  white: '#eee8d5'
+  brightBlack: '#002b36'
+  brightRed: '#cb4b16'
+  brightGreen: '#586e75'
+  brightYellow: '#657b83'
+  brightBlue: '#839496'
+  brightPurple: '#6c71c4'
+  brightCyan: '#93a1a1'
+  brightWhite: '#fdf6e3'
+accent:
+  color: '#268bd2'
+wallpaper:
+  path: '%USERPROFILE%\\Pictures\\Wallpapers\\solarized-dark.jpg'
+editors:
+  vscode:
+    theme: 'Solarized Dark'
+    cursorColor: '#93a1a1'
+    selectionBackground: '#073642'
+  neovim:
+    colorscheme: solarized8_dark
+  notepadpp:
+    theme: 'Solarized Dark'
+  helix:
+    theme: solarized_dark
+  sublimeText:
+    theme: 'Solarized Dark.sublime-theme'
+targets:
+  windowsTerminal:
+    scheme:
+      name: Solarized Dark
+      foreground: '#839496'
+      background: '#002B36'
+      selectionBackground: '#073642'
+      cursorColor: '#93A1A1'
+      black: '#073642'
+      blue: '#268BD2'
+      cyan: '#2AA198'
+      green: '#859900'
+      purple: '#6C71C4'
+      red: '#DC322F'
+      white: '#EEE8D5'
+      yellow: '#B58900'
+      brightBlack: '#002B36'
+      brightBlue: '#839496'
+      brightCyan: '#93A1A1'
+      brightGreen: '#586E75'
+      brightPurple: '#6C71C4'
+      brightRed: '#CB4B16'
+      brightWhite: '#FDF6E3'
+      brightYellow: '#657B83'
+    profileDefaults:
+      colorScheme: Solarized Dark
+  powershell:
+    block: |-
+      # Solarized Dark prompt colors
+      $env:PromptForeground = '#839496'
+      $env:PromptBackground = '#002B36'
+  bash:
+    block: |-
+      # Solarized Dark prompt colors
+      export PS1_COLOR_FG="#839496"
+      export PS1_COLOR_BG="#002B36"
+  windows:
+    accentColor: '#268BD2'
+    wallpaper: '%USERPROFILE%\\Pictures\\Wallpapers\\solarized-dark.jpg'
+  vscode:
+    theme: 'Solarized Dark'
+    colorCustomizations:
+      editor.background: '#002B36'
+      editor.foreground: '#839496'
+      editor.selectionBackground: '#073642'
+      terminal.background: '#002B36'
+      terminal.foreground: '#839496'
+  notepadpp:
+    content: |-
+      <?xml version="1.0" encoding="Windows-1252" ?>
+      <NotepadPlus>
+        <GlobalStyles>
+          <WidgetStyle name="Default Style" fgColor="839496" bgColor="002B36" />
+          <WidgetStyle name="Selected text colour" fgColor="839496" bgColor="073642" />
+        </GlobalStyles>
+      </NotepadPlus>
+  vim:
+    block: |-
+      " Solarized Dark theme integration
+      set background=dark
+      colorscheme solarized8
+      let g:solarized_termtrans=1


### PR DESCRIPTION
## Summary
- add a repository-level `themes` directory so `$env:DOTFILES/themes` contains managed definitions
- author Monokai and Solarized Dark themes with palette, accent, wallpaper, and editor configuration metadata

## Testing
- `pwsh -NoLogo -Command "Set-Location '/workspace/win-wsl_dotfiles'; Set-Item env:DOTFILES '/workspace/win-wsl_dotfiles'; Set-Item env:SYSCOLORS_THEME_PATH (Join-Path $env:DOTFILES 'themes'); Import-Module './readonly_Documents/PowerShell/Modules/SysColors/SysColors.psm1'; SysColors-List -Directory $env:SYSCOLORS_THEME_PATH -Detailed"` *(fails: `pwsh` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1f38321483338b6bc18a87e4d1b6