### PR TITLE
Add DisableNameChecking to SysColors import

### DIFF
--- a/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
+++ b/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
@@ -12,7 +12,7 @@ if ($moduleRoot -and (Test-Path -LiteralPath $moduleRoot)) {
   }
 
   try {
-    Import-Module -Name 'SysColors' -ErrorAction Stop | Out-Null
+    Import-Module -Name 'SysColors' -DisableNameChecking -ErrorAction Stop | Out-Null
   } catch {
     Write-Verbose "SysColors module is not available: $_"
   }


### PR DESCRIPTION
## Summary
- update the PowerShell profile template to disable name checking when importing the SysColors module, avoiding warnings

## Testing
- not run (PowerShell is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc5e6135b48333923f7653bf61218a