### PR TITLE
Avoid reimporting SysColors module on profile reload

### DIFF
--- a/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
+++ b/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
@@ -11,10 +11,12 @@ if ($moduleRoot -and (Test-Path -LiteralPath $moduleRoot)) {
     $env:PSModulePath = ("{0}{1}{2}" -f $moduleRoot, [IO.Path]::PathSeparator, $env:PSModulePath)
   }
 
-  try {
-    Import-Module -Name 'SysColors' -DisableNameChecking -ErrorAction Stop | Out-Null
-  } catch {
-    Write-Verbose "SysColors module is not available: $_"
+  if (-not (Get-Module -Name 'SysColors' -ErrorAction SilentlyContinue)) {
+    try {
+      Import-Module -Name 'SysColors' -DisableNameChecking -ErrorAction Stop | Out-Null
+    } catch {
+      Write-Verbose "SysColors module is not available: $_"
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- guard the SysColors module import in the PowerShell profile so it only runs when the module is not already loaded

## Testing
- not run (environment lacks PowerShell)


------
https://chatgpt.com/codex/tasks/task_e_68cc5f2fbdc08333b136bd6d8faa52c6