### PR TITLE
Avoid creating backups during dry runs

### DIFF
--- a/readonly_Documents/PowerShell/Modules/SysColors/SysColors.psm1
+++ b/readonly_Documents/PowerShell/Modules/SysColors/SysColors.psm1
@@ -312,8 +312,13 @@ function Invoke-SysColorsPlan {
         return @()
     }
 
-    $timestamp     = Get-Date
-    $backupPath    = Get-SysColorsBackupPath -Timestamp $timestamp
+    $timestamp  = $null
+    $backupPath = $null
+
+    if (-not $WhatIf -and -not $SkipBackup) {
+        $timestamp  = Get-Date
+        $backupPath = Get-SysColorsBackupPath -Timestamp $timestamp
+    }
     $manifestItems = @()
 
     foreach ($step in $planItems) {
@@ -335,13 +340,13 @@ function Invoke-SysColorsPlan {
         }
     }
 
-    if (-not $WhatIf -and -not $SkipBackup) {
+    if ($backupPath) {
         Save-SysColorsManifest -Entries $manifestItems -Destination $backupPath
     }
 
     [pscustomobject]@{
         Timestamp  = $timestamp
-        BackupPath = if ($SkipBackup) { $null } else { $backupPath }
+        BackupPath = $backupPath
         Steps      = $planItems
     }
 }


### PR DESCRIPTION
## Summary
- avoid creating backup directories when running Invoke-SysColorsPlan with -WhatIf or -SkipBackup
- ensure Save-SysColorsManifest and the return object handle a missing backup path

## Testing
- not run (PowerShell is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc6620bb8483339c9a9480fed2791d