### PR TITLE
Add SysColor wrapper helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,19 @@ Usage overview:
 5. Restore the most recent backup with `SysColors-Restore -Latest` or list backups
    with `SysColors-Restore -List` before selecting a specific snapshot.
 
+### Quick SysColor helper
+
+The module also exports a compact `SysColor` helper (alias `sc`) that wraps the
+main cmdlets:
+
+- `SysColor -themes` lists available themes (same as `SysColors-List`).
+- `SysColor -backups` shows the saved snapshots (same as `SysColors-Restore -List`).
+- `SysColor -back` restores the most recent snapshot (same as `SysColors-Restore -Latest`).
+- `SysColor -config <Theme>` or a direct switch such as `SysColor -monokai` applies
+  a theme via `SysColors`.
+
+Combine the helper with `-WhatIf` and `-SkipBackup` to forward the options to the
+underlying cmdlets.
+
 Theme files live beside the module in the `themes` folder. Create new themes by
 following the schema shown in `example.yml`.

--- a/readonly_Documents/PowerShell/Modules/SysColors/SysColors.psd1
+++ b/readonly_Documents/PowerShell/Modules/SysColors/SysColors.psd1
@@ -7,8 +7,8 @@
     Copyright         = '(c) Dotfiles. All rights reserved.'
     Description       = 'Applies color themes defined in YAML across Windows, WSL, and editors.'
     PowerShellVersion = '5.1'
-    FunctionsToExport = @('SysColors', 'SysColors-List', 'SysColors-Where', 'SysColors-Restore')
+    FunctionsToExport = @('SysColors', 'SysColors-List', 'SysColors-Where', 'SysColors-Restore', 'SysColor')
     CmdletsToExport   = @()
-    AliasesToExport   = @()
+    AliasesToExport   = @('sc')
     PrivateData       = @{}
 }


### PR DESCRIPTION
## Summary
- add a SysColor convenience function that wraps theme listing, application, and restore helpers
- export the new function and an `sc` alias from the module manifest
- document the shortcut usage in the README

## Testing
- not run (PowerShell module depends on external tooling not available in CI)


------
https://chatgpt.com/codex/tasks/task_e_68ccf8e902508333a213172b08563e77