### PR TITLE
Make SysColors wallpapers optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,6 @@ Combine the helper with `-WhatIf` and `-SkipBackup` to forward the options to th
 underlying cmdlets.
 
 Theme files live beside the module in the `themes` folder. Create new themes by
-following the schema shown in `example.yml`.
+following the schema shown in `example.yml`. Wallpaper entries are optional—leave
+the `wallpaper.path` or `targets.windows.wallpaper` values empty (`''`) to skip
+changing the desktop background when applying a theme.

--- a/readonly_Documents/PowerShell/Modules/SysColors/SysColors.psm1
+++ b/readonly_Documents/PowerShell/Modules/SysColors/SysColors.psm1
@@ -592,8 +592,9 @@ function New-SysColorsWindowsAccentStep {
             }
         }
 
-        if ($step.Metadata.Wallpaper) {
-            $path = Expand-SysColorsPath -Path $step.Metadata.Wallpaper
+        $wallpaper = $step.Metadata.Wallpaper
+        if ($null -ne $wallpaper -and -not [string]::IsNullOrWhiteSpace($wallpaper)) {
+            $path = Expand-SysColorsPath -Path $wallpaper
             if (Test-Path -LiteralPath $path) {
                 rundll32.exe user32.dll, UpdatePerUserSystemParameters 1, True
                 Set-ItemProperty -Path 'HKCU:\Control Panel\Desktop' -Name 'Wallpaper' -Value $path -ErrorAction SilentlyContinue

--- a/readonly_Documents/PowerShell/Modules/SysColors/themes/example.yml
+++ b/readonly_Documents/PowerShell/Modules/SysColors/themes/example.yml
@@ -44,7 +44,8 @@ targets:
       export EXAMPLE_THEME="Example Theme"
   windows:
     accentColor: '#1E90FF'
-    wallpaper: '%USERPROFILE%\\Pictures\\example.jpg'
+    # Wallpaper path is optional; leave empty to skip updating the desktop background.
+    wallpaper: ''
   vscode:
     theme: Default Dark+
     colorCustomizations:

--- a/themes/monokai.yml
+++ b/themes/monokai.yml
@@ -27,7 +27,7 @@ palette:
 accent:
   color: '#AE81FF'
 wallpaper:
-  path: '%USERPROFILE%\\Pictures\\Wallpapers\\monokai.jpg'
+  path: ''
 editors:
   vscode:
     theme: 'Monokai Dimmed'
@@ -79,7 +79,7 @@ targets:
       export PS1_COLOR_BG="#272822"
   windows:
     accentColor: '#AE81FF'
-    wallpaper: '%USERPROFILE%\\Pictures\\Wallpapers\\monokai.jpg'
+    wallpaper: ''
   vscode:
     theme: 'Monokai Dimmed'
     colorCustomizations:

--- a/themes/solarized-dark.yml
+++ b/themes/solarized-dark.yml
@@ -27,7 +27,7 @@ palette:
 accent:
   color: '#268bd2'
 wallpaper:
-  path: '%USERPROFILE%\\Pictures\\Wallpapers\\solarized-dark.jpg'
+  path: ''
 editors:
   vscode:
     theme: 'Solarized Dark'
@@ -79,7 +79,7 @@ targets:
       export PS1_COLOR_BG="#002B36"
   windows:
     accentColor: '#268BD2'
-    wallpaper: '%USERPROFILE%\\Pictures\\Wallpapers\\solarized-dark.jpg'
+    wallpaper: ''
   vscode:
     theme: 'Solarized Dark'
     colorCustomizations:


### PR DESCRIPTION
## Summary
- clear the wallpaper settings in the Monokai and Solarized Dark themes and document that wallpaper paths are optional
- make the Windows accent step skip empty wallpaper values
- update the example theme and README with guidance on leaving wallpaper paths blank

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccfbfc2f148333b4d75cd687c88b4d